### PR TITLE
a few optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["agglomerative", "hierarchical", "cluster", "fastcluster", "linkage"]
 license = "MIT"
 exclude = ["data/locations/*.dist"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = ["kodama-bin", "kodama-capi"]
@@ -31,10 +31,17 @@ lazy_static = "1.4.0"
 quickcheck = { version = "1.0.3", default-features = false }
 
 [profile.release]
-debug = true
+lto = true
+codegen-units = 1
+opt-level = 3
+panic = "abort"
 
 [profile.bench]
 debug = true
+lto = true
+codegen-units = 1
+opt-level = 3
+panic = "abort"
 
 [profile.test]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-kodama
-======
+# kodama
+
+### Changes made over the original [crate](https://github.com/diffeo/kodama): 
+
+- Update Rust edition from 2018 to 2021
+- Merge [`ag/updates`](https://github.com/diffeo/kodama/tree/ag/updates) branch into master
+- Heavier use of `#[inline]`
+- Use `codegen = 1`, `lto = true` and `opt-level = 3` in `cargo.toml` for release version
+- Use `panic = abort` (plays nicely with inlining and making more code fit in instructions cache)
+- A few other small changes
+
 This crate provides a fast implementation of agglomerative
 [hierarchical clustering](https://en.wikipedia.org/wiki/Hierarchical_clustering).
 
@@ -33,13 +42,13 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-kodama = "0.1"
+kodama = { git = "https://github.com/SubconsciousCompute/kodama" }
 ```
 
 and this to your crate root:
 
 ```rust
-extern crate kodama;
+use kodama;
 ```
 
 ### C API and Go bindings

--- a/src/active.rs
+++ b/src/active.rs
@@ -18,11 +18,13 @@ pub struct Active {
 
 impl Active {
     /// Create a new empty active list.
+    #[inline]
     pub fn new() -> Active {
         Active { start: 0, prev: vec![], next: vec![] }
     }
 
     /// Create a new active list with elements `0` through `len-1`, inclusive.
+    #[inline]
     pub fn with_len(len: usize) -> Active {
         let mut a = Active::new();
         a.reset(len);
@@ -32,6 +34,7 @@ impl Active {
     /// Reset this list to the given length as if a new list were created.
     ///
     /// This permits reusing this list's allocation.
+    #[inline]
     pub fn reset(&mut self, len: usize) {
         self.start = 0;
         self.prev.resize(len, 0);
@@ -46,6 +49,7 @@ impl Active {
     /// Return true if the given element is still in the list.
     ///
     /// This runs in constant time.
+    #[inline]
     pub fn contains(&self, i: usize) -> bool {
         self.next[i] > 0
     }
@@ -55,6 +59,7 @@ impl Active {
     /// If the given element has already been removed, then this is a no-op.
     ///
     /// This runs in constant time.
+    #[inline]
     pub fn remove(&mut self, i: usize) {
         if !self.contains(i) {
             return;
@@ -75,6 +80,7 @@ impl Active {
     ///
     /// The iterator runs in time proportional to the number of elements in
     /// the list.
+    #[inline]
     pub fn iter(&self) -> ActiveIter<'_> {
         ActiveIter(ActiveRange {
             active: self,
@@ -90,6 +96,7 @@ impl Active {
     /// elements in the list in the given range. Otherwise, no such guarantee
     /// is provided, but has an upper bound on the total number of elements
     /// that have ever been in the list.
+    #[inline]
     pub fn range<R: RangeBound<usize>>(&self, range: R) -> ActiveRange<'_> {
         let mut start = match range.start() {
             Bound::Unbounded => self.start,
@@ -113,13 +120,14 @@ impl Active {
         while start < self.next.len() && !self.contains(start) {
             start += 1;
         }
-        ActiveRange { active: self, cur: start, end: end }
+        ActiveRange { active: self, cur: start, end }
     }
 }
 
 impl<'a> IntoIterator for &'a Active {
-    type IntoIter = ActiveIter<'a>;
     type Item = usize;
+    type IntoIter = ActiveIter<'a>;
+    #[inline]
     fn into_iter(self) -> ActiveIter<'a> {
         self.iter()
     }
@@ -166,7 +174,7 @@ impl<'a> Iterator for ActiveRange<'a> {
 
 /// A trait that abstracts over the different types of ranges.
 ///
-/// We define this ourselves until std::collections::range stabilizes.
+/// We define this ourselves until `std::collections::range` stabilizes.
 pub trait RangeBound<T> {
     /// Return the start bound.
     fn start(&self) -> Bound<&T>;
@@ -175,36 +183,44 @@ pub trait RangeBound<T> {
 }
 
 impl<T> RangeBound<T> for RangeFull {
+    #[inline]
     fn start(&self) -> Bound<&T> {
         Bound::Unbounded
     }
+    #[inline]
     fn end(&self) -> Bound<&T> {
         Bound::Unbounded
     }
 }
 
 impl<T> RangeBound<T> for RangeFrom<T> {
+    #[inline]
     fn start(&self) -> Bound<&T> {
         Bound::Included(&self.start)
     }
+    #[inline]
     fn end(&self) -> Bound<&T> {
         Bound::Unbounded
     }
 }
 
 impl<T> RangeBound<T> for RangeTo<T> {
+    #[inline]
     fn start(&self) -> Bound<&T> {
         Bound::Unbounded
     }
+    #[inline]
     fn end(&self) -> Bound<&T> {
         Bound::Excluded(&self.end)
     }
 }
 
 impl<T> RangeBound<T> for Range<T> {
+    #[inline]
     fn start(&self) -> Bound<&T> {
         Bound::Included(&self.start)
     }
+    #[inline]
     fn end(&self) -> Bound<&T> {
         Bound::Excluded(&self.end)
     }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -13,6 +13,7 @@ use crate::{LinkageState, MethodChain};
 /// [`linkage`](fn.linkage.html),
 /// since it tries to pick the fastest algorithm depending on the method
 /// supplied.
+#[inline]
 pub fn nnchain<T: Float>(
     dis: &mut [T],
     observations: usize,

--- a/src/condensed.rs
+++ b/src/condensed.rs
@@ -43,27 +43,30 @@ impl<'a, T> CondensedMatrix<'a, T> {
     /// As a special case, if `observations` is `<= 1`, then it is treated as
     /// if it is equivalent to `0`. In this case, the matrix provided must be
     /// empty.
+    #[inline]
     pub fn new(
         data: &'a mut [T],
         observations: usize,
     ) -> CondensedMatrix<'a, T> {
         if data.is_empty() {
             assert!(observations <= 1);
-            CondensedMatrix { data: data, observations: 0 }
+            CondensedMatrix { data, observations: 0 }
         } else {
             assert!(observations >= 2);
             assert_eq!((observations * (observations - 1)) / 2, data.len());
-            CondensedMatrix { data: data, observations: observations }
+            CondensedMatrix { data, observations }
         }
     }
 
     /// Return the number of observations that make up this matrix.
+    #[inline]
     pub fn observations(&self) -> usize {
         self.observations
     }
 
     /// Convert the given row and column 2-dimensional index into an index
     /// into the condensed matrix.
+    #[inline]
     fn matrix_to_condensed_idx(&self, row: usize, column: usize) -> usize {
         debug_assert!(row < column);
         debug_assert!(column < self.observations());
@@ -84,12 +87,14 @@ impl<'a, T> CondensedMatrix<'a, T> {
 impl<'a, T> Index<[usize; 2]> for CondensedMatrix<'a, T> {
     type Output = T;
 
+    #[inline]
     fn index(&self, idx: [usize; 2]) -> &T {
         &self.data[self.matrix_to_condensed_idx(idx[0], idx[1])]
     }
 }
 
 impl<'a, T> IndexMut<[usize; 2]> for CondensedMatrix<'a, T> {
+    #[inline]
     fn index_mut(&mut self, idx: [usize; 2]) -> &mut T {
         let i = self.matrix_to_condensed_idx(idx[0], idx[1]);
         &mut self.data[i]

--- a/src/dendrogram.rs
+++ b/src/dendrogram.rs
@@ -26,7 +26,7 @@ use crate::float::Float;
 ///    `(N + N - 1) - 1` (since there are always `N - 1` steps in a
 ///    dendrogram).
 ///
-/// This labeling scheme corresponds to the same labeling scheme used by SciPy.
+/// This labeling scheme corresponds to the same labeling scheme used by `SciPy`.
 ///
 /// The type parameter `T` refers to the type of dissimilarity used in the
 /// steps. In practice, `T` is a floating point type.
@@ -75,11 +75,9 @@ pub struct Step<T> {
 impl<T> Dendrogram<T> {
     /// Return a new dendrogram with space for the given number of
     /// observations.
+    #[inline]
     pub fn new(observations: usize) -> Dendrogram<T> {
-        Dendrogram {
-            steps: Vec::with_capacity(observations),
-            observations: observations,
-        }
+        Dendrogram { steps: Vec::with_capacity(observations), observations }
     }
 
     /// Clear this dendrogram and ensure there is space for the given number
@@ -90,6 +88,7 @@ impl<T> Dendrogram<T> {
     /// Note that this method does not need to be called before passing it to
     /// one of the clustering functions. The clustering functions will reset
     /// the dendrogram for you.
+    #[inline]
     pub fn reset(&mut self, observations: usize) {
         self.steps.clear();
         self.observations = observations;
@@ -101,32 +100,38 @@ impl<T> Dendrogram<T> {
     ///
     /// This method panics if the dendrogram has `N - 1` steps, where `N` is
     /// the number of observations supported by this dendrogram.
+    #[inline]
     pub fn push(&mut self, step: Step<T>) {
         assert!(self.len() < self.observations().saturating_sub(1));
         self.steps.push(step);
     }
 
     /// Returns the steps in the dendrogram.
+    #[inline]
     pub fn steps(&self) -> &[Step<T>] {
         &self.steps
     }
 
     /// Return a mutable slice of the steps in this dendrogram.
+    #[inline]
     pub fn steps_mut(&mut self) -> &mut [Step<T>] {
         &mut self.steps
     }
 
     /// Return the number of steps in this dendrogram.
+    #[inline]
     pub fn len(&self) -> usize {
         self.steps.len()
     }
 
     /// Return true if and only if this dendrogram has no steps.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.steps.is_empty()
     }
 
     /// Return the number of observations that this dendrogram supports.
+    #[inline]
     pub fn observations(&self) -> usize {
         self.observations
     }
@@ -136,6 +141,7 @@ impl<T> Dendrogram<T> {
     ///
     /// The label may be any value in the half-open interval
     /// `[0, N + N - 1)`, where `N` is the total number of observations.
+    #[inline]
     pub fn cluster_size(&self, label: usize) -> usize {
         if label < self.observations() {
             1
@@ -152,6 +158,7 @@ impl<T: Float> Dendrogram<T> {
     /// step. In particular, two dissimilarities are considered equal if and
     /// only if the absolute value of their difference is less than or equal to
     /// the given `epsilon` value.
+    #[inline]
     pub fn eq_with_epsilon(&self, other: &Dendrogram<T>, epsilon: T) -> bool {
         if self.len() != other.len() {
             return false;
@@ -167,12 +174,14 @@ impl<T: Float> Dendrogram<T> {
 
 impl<T> ops::Index<usize> for Dendrogram<T> {
     type Output = Step<T>;
+    #[inline]
     fn index(&self, i: usize) -> &Step<T> {
         &self.steps[i]
     }
 }
 
 impl<T> ops::IndexMut<usize> for Dendrogram<T> {
+    #[inline]
     fn index_mut(&mut self, i: usize) -> &mut Step<T> {
         &mut self.steps[i]
     }
@@ -183,6 +192,7 @@ impl<T> Step<T> {
     ///
     /// Note that the clustering labels given are normalized such that the
     /// smallest label is always assigned to `cluster1`.
+    #[inline]
     pub fn new(
         mut cluster1: usize,
         mut cluster2: usize,
@@ -192,18 +202,14 @@ impl<T> Step<T> {
         if cluster2 < cluster1 {
             mem::swap(&mut cluster1, &mut cluster2);
         }
-        Step {
-            cluster1: cluster1,
-            cluster2: cluster2,
-            dissimilarity: dissimilarity,
-            size: size,
-        }
+        Step { cluster1, cluster2, dissimilarity, size }
     }
 
     /// Set the cluster labels on this step.
     ///
     /// Note that the clustering labels given are normalized such that the
     /// smallest label is always assigned to `cluster1`.
+    #[inline]
     pub fn set_clusters(&mut self, mut cluster1: usize, mut cluster2: usize) {
         if cluster2 < cluster1 {
             mem::swap(&mut cluster1, &mut cluster2);
@@ -220,6 +226,7 @@ impl<T: Float> Step<T> {
     /// step. In particular, two dissimilarity are considered equal if and only
     /// if the absolute value of their difference is less than or equal to the
     /// given `epsilon` value.
+    #[inline]
     pub fn eq_with_epsilon(&self, other: &Step<T>, epsilon: T) -> bool {
         if self == other {
             return true;

--- a/src/float.rs
+++ b/src/float.rs
@@ -37,60 +37,74 @@ pub trait Float:
 }
 
 impl Float for f32 {
+    #[inline]
     fn from_usize(v: usize) -> f32 {
         v as f32
     }
 
+    #[inline]
     fn from_float<F: Float>(v: F) -> f32 {
         v.to_f64() as f32
     }
 
+    #[inline]
     fn to_f64(self) -> f64 {
         self as f64
     }
 
+    #[inline]
     fn infinity() -> f32 {
         f32::INFINITY
     }
 
+    #[inline]
     fn max_value() -> f32 {
         f32::MAX
     }
 
+    #[inline]
     fn sqrt(self) -> f32 {
         f32::sqrt(self)
     }
 
+    #[inline]
     fn abs(self) -> f32 {
         f32::abs(self)
     }
 }
 
 impl Float for f64 {
+    #[inline]
     fn from_usize(v: usize) -> f64 {
         v as f64
     }
 
+    #[inline]
     fn from_float<F: Float>(v: F) -> f64 {
         v.to_f64()
     }
 
+    #[inline]
     fn to_f64(self) -> f64 {
         self
     }
 
+    #[inline]
     fn infinity() -> f64 {
         f64::INFINITY
     }
 
+    #[inline]
     fn max_value() -> f64 {
         f64::MAX
     }
 
+    #[inline]
     fn sqrt(self) -> f64 {
         f64::sqrt(self)
     }
 
+    #[inline]
     fn abs(self) -> f64 {
         f64::abs(self)
     }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -10,6 +10,7 @@ use crate::{LinkageState, Method};
 /// [`linkage`](fn.linkage.html),
 /// since it tries to pick the fastest algorithm depending on the method
 /// supplied.
+#[inline]
 pub fn generic<T: Float>(
     condensed_dissimilarity_matrix: &mut [T],
     observations: usize,

--- a/src/method.rs
+++ b/src/method.rs
@@ -55,10 +55,10 @@ pub fn centroid<T: Float>(
 ) {
     let size_a = T::from_usize(size_a);
     let size_b = T::from_usize(size_b);
-    let size_ab = size_a + size_b;
+    let size_a_plus_b = size_a + size_b;
 
-    *b = (((size_a * a) + (size_b * *b)) / size_ab)
-        - ((size_a * size_b * merged_dist) / (size_ab * size_ab));
+    *b = (((size_a * a) + (size_b * *b)) / size_a_plus_b)
+        - ((size_a * size_b * merged_dist) / (size_a_plus_b * size_a_plus_b));
 }
 
 #[inline]

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -12,6 +12,7 @@ use crate::{LinkageState, Method};
 /// hierarchical clustering, and is therefore terribly slow. Use
 /// [`linkage`](fn.linkage.html)
 /// instead to have the appropriate algorithm chosen for you.
+#[inline]
 pub fn primitive<T: Float>(
     dis: &mut [T],
     observations: usize,
@@ -200,7 +201,7 @@ fn argmin<T: Float>(
     // minimum.
     let mut min = match active.iter().next() {
         None => return None,
-        Some(row) => match active.range(row..).skip(1).next() {
+        Some(row) => match active.range(row..).nth(1) {
             None => return None,
             Some(col) => (row, col, matrix[[row, col]]),
         },

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -22,10 +22,12 @@ pub struct LinkageHeap<T> {
 }
 
 impl<T: Float> LinkageHeap<T> {
+    #[inline]
     pub fn new() -> LinkageHeap<T> {
         LinkageHeap::with_len(0)
     }
 
+    #[inline]
     pub fn with_len(len: usize) -> LinkageHeap<T> {
         LinkageHeap {
             heap: (0..len).collect(),
@@ -35,6 +37,7 @@ impl<T: Float> LinkageHeap<T> {
         }
     }
 
+    #[inline]
     pub fn reset(&mut self, len: usize) {
         self.heap.resize(len, 0);
         self.observations.resize(len, 0);
@@ -49,14 +52,17 @@ impl<T: Float> LinkageHeap<T> {
         }
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.heap.len()
     }
 
+    #[inline]
     pub fn pop(&mut self) -> Option<usize> {
         if self.is_empty() {
             return None;
@@ -74,6 +80,7 @@ impl<T: Float> LinkageHeap<T> {
         Some(last)
     }
 
+    #[inline]
     pub fn peek(&self) -> Option<usize> {
         if self.is_empty() {
             None
@@ -82,6 +89,7 @@ impl<T: Float> LinkageHeap<T> {
         }
     }
 
+    #[inline]
     pub fn heapify<F: FnMut(&mut [T])>(&mut self, mut f: F) {
         let len = self.priorities.len();
         self.reset(len);
@@ -93,11 +101,13 @@ impl<T: Float> LinkageHeap<T> {
         }
     }
 
+    #[inline]
     pub fn priority(&self, observation: usize) -> &T {
         assert!(!self.removed[observation]);
         &self.priorities[observation]
     }
 
+    #[inline]
     pub fn set_priority(&mut self, observation: usize, priority: T) {
         assert!(!self.removed[observation]);
 
@@ -110,12 +120,10 @@ impl<T: Float> LinkageHeap<T> {
         }
     }
 
+    #[inline]
     fn sift_up(&mut self, o: usize) {
         loop {
-            let po = match self.parent(o) {
-                None => break,
-                Some(po) => po,
-            };
+            let Some(po) = self.parent(o) else { break };
             if self.priorities[po] < self.priorities[o] {
                 break;
             }
@@ -123,6 +131,7 @@ impl<T: Float> LinkageHeap<T> {
         }
     }
 
+    #[inline]
     fn sift_down(&mut self, o: usize) {
         loop {
             let mut child = o;
@@ -144,6 +153,7 @@ impl<T: Float> LinkageHeap<T> {
         }
     }
 
+    #[inline]
     fn parent(&self, o: usize) -> Option<usize> {
         if self.observations[o] == 0 {
             None
@@ -152,12 +162,14 @@ impl<T: Float> LinkageHeap<T> {
         }
     }
 
+    #[inline]
     fn children(&self, o: usize) -> (Option<usize>, Option<usize>) {
         let i = self.observations[o];
         let (left, right) = (2 * i + 1, 2 * i + 2);
-        (self.heap.get(left).cloned(), self.heap.get(right).cloned())
+        (self.heap.get(left).copied(), self.heap.get(right).copied())
     }
 
+    #[inline]
     fn swap(&mut self, o1: usize, o2: usize) {
         self.heap.swap(self.observations[o1], self.observations[o2]);
         self.observations.swap(o1, o2);

--- a/src/spanning.rs
+++ b/src/spanning.rs
@@ -11,6 +11,7 @@ use crate::{LinkageState, Method};
 /// [`linkage`](fn.linkage.html),
 /// since it tries to pick the fastest algorithm depending on the method
 /// supplied.
+#[inline]
 pub fn mst<T: Float>(dis: &mut [T], observations: usize) -> Dendrogram<T> {
     let mut state = LinkageState::new();
     let mut steps = Dendrogram::new(observations);

--- a/src/test.rs
+++ b/src/test.rs
@@ -18,6 +18,7 @@ impl DistinctMatrix {
     /// dissimilarity matrix.
     ///
     /// Also, any NaN values in the matrix are replaced with `0`.
+    #[inline]
     pub fn new(mut mat: Vec<f64>) -> DistinctMatrix {
         make_distinct(&mut mat);
 
@@ -44,17 +45,20 @@ impl DistinctMatrix {
     }
 
     /// Return a copy of the condensed pairwise dissimilarity matrix.
+    #[inline]
     pub fn matrix(&self) -> Vec<f64> {
         self.matrix.to_vec()
     }
 
     /// Return the number of observations in this matrix.
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
 }
 
 impl Arbitrary for DistinctMatrix {
+    #[inline]
     fn arbitrary(_g: &mut Gen) -> DistinctMatrix {
         let mut rng = rand::thread_rng();
         let size = rng.gen_range(0..30);
@@ -67,6 +71,7 @@ impl Arbitrary for DistinctMatrix {
         DistinctMatrix::new(dis)
     }
 
+    #[inline]
     fn shrink(&self) -> Box<dyn Iterator<Item = DistinctMatrix>> {
         Box::new(self.matrix.shrink().map(DistinctMatrix::new))
     }
@@ -88,6 +93,7 @@ fn make_distinct(xs: &mut Vec<f64>) {
     impl Eq for NonNanF64 {}
 
     impl Ord for NonNanF64 {
+        #[inline]
         fn cmp(&self, other: &NonNanF64) -> Ordering {
             self.0.partial_cmp(&other.0).unwrap()
         }
@@ -116,6 +122,7 @@ fn make_distinct(xs: &mut Vec<f64>) {
 ///
 /// Note that the size may be invalid. For example, a condensed matrix of
 /// size `2` isn't valid.
+#[inline]
 fn observations(condensed_matrix_size: usize) -> usize {
     ((condensed_matrix_size as f64) * 2.0).sqrt().ceil() as usize
 }

--- a/src/union.rs
+++ b/src/union.rs
@@ -23,6 +23,7 @@ pub struct LinkageUnionFind {
 }
 
 impl Default for LinkageUnionFind {
+    #[inline]
     fn default() -> LinkageUnionFind {
         LinkageUnionFind::new()
     }
@@ -30,12 +31,14 @@ impl Default for LinkageUnionFind {
 
 impl LinkageUnionFind {
     /// Create a new empty set.
+    #[inline]
     pub fn new() -> LinkageUnionFind {
         LinkageUnionFind::with_len(0)
     }
 
     /// Create a new set that can merge clusters for exactly `len`
     /// observations.
+    #[inline]
     pub fn with_len(len: usize) -> LinkageUnionFind {
         let size = if len == 0 { 0 } else { 2 * len - 1 };
         LinkageUnionFind { parents: (0..size).collect(), next_parent: len }
@@ -43,6 +46,7 @@ impl LinkageUnionFind {
 
     /// Clear this allocation and resize it as appropriate to support `len`
     /// observations.
+    #[inline]
     pub fn reset(&mut self, len: usize) {
         let size = if len == 0 { 0 } else { 2 * len - 1 };
         self.next_parent = len;
@@ -55,6 +59,7 @@ impl LinkageUnionFind {
     /// Union the two clusters represented by the given labels.
     ///
     /// If the two clusters have already been merged, then this is a no-op.
+    #[inline]
     pub fn union(&mut self, cluster1: usize, cluster2: usize) {
         // If the clusters are already in the same set, then
         // this is a no-op.
@@ -65,10 +70,11 @@ impl LinkageUnionFind {
         assert!(self.next_parent < self.parents.len());
         self.parents[cluster1] = self.next_parent;
         self.parents[cluster2] = self.next_parent;
-        self.next_parent = self.next_parent + 1;
+        self.next_parent += 1;
     }
 
     /// Return the root cluster label containing the cluster given.
+    #[inline]
     pub fn find(&mut self, mut cluster: usize) -> usize {
         // Find the parent of this cluster. The parent
         // is the "label" of the cluster and is a root
@@ -89,6 +95,7 @@ impl LinkageUnionFind {
 
     /// Return the parent of the given cluster, if one exists. If the given
     /// cluster is a root, then `None` is returned.
+    #[inline]
     fn parent(&self, cluster: usize) -> Option<usize> {
         let p = self.parents[cluster];
         if p == cluster {
@@ -102,6 +109,7 @@ impl LinkageUnionFind {
     ///
     /// If the given method requires the dendrogram to be sorted, then the
     /// steps of the dendrogram are sorted by their dissimilarities.
+    #[inline]
     pub fn relabel<T: PartialOrd>(
         &mut self,
         dendrogram: &mut Dendrogram<T>,


### PR DESCRIPTION
- Update Rust edition from 2018 to 2021
- Merge [`ag/updates`](https://github.com/diffeo/kodama/tree/ag/updates) branch into master
- Heavier use of `#[inline]`
- Use `codegen = 1`, `lto = true` and `opt-level = 3` in `cargo.toml` for release version
- Use `panic = abort` (plays nicely with inlining and making more code fit in instructions cache)
- A few other small changes